### PR TITLE
[Selenium] Add DecoratorManager.withDecorators for scoped decorator application

### DIFF
--- a/core/selenium/api/selenium.api
+++ b/core/selenium/api/selenium.api
@@ -167,6 +167,7 @@ public final class dev/kolibrium/core/selenium/decorators/DecoratorManager {
 	public static final field INSTANCE Ldev/kolibrium/core/selenium/decorators/DecoratorManager;
 	public final fun addDecorators ([Ldev/kolibrium/core/selenium/decorators/AbstractDecorator;)V
 	public final fun clearDecorators ()V
+	public final fun withDecorators ([Ldev/kolibrium/core/selenium/decorators/AbstractDecorator;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class dev/kolibrium/core/selenium/decorators/ElementStateCacheDecorator : dev/kolibrium/core/selenium/decorators/AbstractDecorator {

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/AbstractDecorator.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/AbstractDecorator.kt
@@ -21,12 +21,20 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 
 /**
- * Base abstract class for implementing WebDriver decorators following the decorator pattern.
- * Provides a structured way to add behaviors to both WebDriver and WebElement instances.
+ * Base type for Kolibrium decorators.
  *
- * This class handles the initial [SearchContext] type checking and routing to appropriate
- * decoration methods, while concrete implementations define specific behaviors by overriding
- * [decorateDriver] and [decorateElement].
+ * A decorator augments Selenium objects while keeping the original API untouched. In Kolibrium
+ * we decorate the [SearchContext] contract itself (both [WebDriver] and [WebElement] implement it)
+ * so that returned elements are also decorated, enabling safe chaining across nested component trees.
+ *
+ * Implementors usually override [decorateSearchContext] to intercept `findElement(s)` and return
+ * elements wrapped via [decorateElement]. If you need to alter element behaviour (e.g. cache state
+ * or add side‑effects), provide those overrides in [decorateElement].
+ *
+ * Notes
+ * - This mechanism is independent of Selenium’s EventFiringDecorator. Some decorators may still use
+ *   a [org.openqa.selenium.support.events.WebDriverListener] internally for interaction callbacks,
+ *   but chaining is always preserved through the Kolibrium wrappers.
  *
  * @see SearchContext
  * @see WebDriver

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/ElementStateCacheDecorator.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/ElementStateCacheDecorator.kt
@@ -23,26 +23,19 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 
 /**
- * A decorator that caches positive state check results (`true` values) for WebElement state methods:
- * [WebElement.isDisplayed], [WebElement.isEnabled] and [WebElement.isSelected].
+ * Caches positive results for element state checks to reduce WebDriver calls.
  *
- * This decorator optimizes performance by caching `true` results from state checks, eliminating
- * redundant WebDriver calls when an element is known to be in a positive state. Only `true` results
- * are cached - negative results (`false`) are always checked against the actual element state.
+ * The decorator wraps elements so that repeated calls to [WebElement.isDisplayed], [WebElement.isEnabled]
+ * and/or [WebElement.isSelected] can short‑circuit once a `true` value has been observed. Negative results
+ * are never cached. Each decorated element instance keeps its own independent cache.
  *
- * State caching behavior:
- * - When a state check returns `true`, the result is cached.
- * - When a state check returns `false`, the result is not cached.
- * - Subsequent checks for a cached `true` state return immediately without WebDriver interaction.
- * - Each decorated element maintains its own independent state cache.
+ * Caveats
+ * - Dynamic UIs that toggle state may make caches stale. Prefer leaving [cacheSelected] false unless you
+ *   clear caches after interactions. Consider using this decorator only for read‑mostly states.
  *
- * Note: This decorator assumes that once an element becomes displayed, enabled or selected, it remains
- * in that state for the duration of the test. If your application can toggle these states dynamically,
- * consider not using this decorator or clearing the cache when state changes are possible.
- *
- * @param cacheDisplayed Whether to cache positive results from [WebElement.isDisplayed] calls.
- * @param cacheEnabled Whether to cache positive results from [WebElement.isEnabled] calls.
- * @param cacheSelected Whether to cache positive results from [WebElement.isSelected] calls.
+ * @param cacheDisplayed Cache positive results from [WebElement.isDisplayed]. Default: true.
+ * @param cacheEnabled Cache positive results from [WebElement.isEnabled]. Default: false.
+ * @param cacheSelected Cache positive results from [WebElement.isSelected]. Default: false.
  * @see WebElement.isDisplayed
  * @see WebElement.isEnabled
  * @see WebElement.isSelected

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/ListenerSupport.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/ListenerSupport.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.core.selenium.decorators
+
+import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.SearchContext
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.WrapsDriver
+import org.openqa.selenium.support.events.EventFiringDecorator
+import org.openqa.selenium.support.events.WebDriverListener
+
+/**
+ * Wraps the provided [SearchContext] with an [EventFiringDecorator] using the given [listener]
+ * if the context is a [WebDriver]. Otherwise, returns the original context unchanged.
+ */
+internal fun wrapWithListenerIfDriver(
+    context: SearchContext,
+    listener: WebDriverListener,
+): SearchContext =
+    if (context is WebDriver) {
+        EventFiringDecorator<WebDriver>(listener).decorate(context)
+    } else {
+        context
+    }
+
+/**
+ * Attempts to obtain a [JavascriptExecutor] from the provided [WebElement] by unwrapping
+ * its [WebDriver] using [WrapsDriver]. Returns null if not available.
+ */
+internal fun WebElement.tryGetJsExecutor(): JavascriptExecutor? = (this as? WrapsDriver)?.wrappedDriver as? JavascriptExecutor

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/SlowMotionDecorator.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/decorators/SlowMotionDecorator.kt
@@ -21,16 +21,22 @@ import org.openqa.selenium.By
 import org.openqa.selenium.SearchContext
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.events.WebDriverListener
 import java.lang.Thread.sleep
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 /**
- * Decorator that adds configurable delay to Selenium WebDriver operations.
- * Useful for debugging, demonstrations, or slowing down test execution for visualization purposes.
+ * Decorator that inserts delays to make browser actions easier to observe.
  *
- * @param wait The duration to wait after each decorated operation.
+ * By default the delay is applied only before element interactions (click, sendKeys) using a
+ * Selenium [org.openqa.selenium.support.events.WebDriverListener]. Chaining is preserved by
+ * wrapping elements returned from `findElement(s)`.
+ *
+ * Typical uses: demos, debugging flakiness visually, recordings.
+ *
+ * @param wait Duration of the delay to add. Must be non-negative. Default: 1 second.
  */
 public class SlowMotionDecorator(
     private val wait: Duration = 1.seconds,
@@ -40,15 +46,16 @@ public class SlowMotionDecorator(
     }
 
     override fun decorateSearchContext(context: SearchContext): SearchContext {
-        return object : SearchContext by context {
+        val base = wrapWithListenerIfDriver(context, SlowListener())
+        return object : SearchContext by base {
             override fun findElement(by: By): WebElement {
-                val foundElement = context.findElement(by)
+                val foundElement = base.findElement(by)
                 addDelay()
                 return decorateElement(foundElement)
             }
 
             override fun findElements(by: By): WebElements {
-                val elements = context.findElements(by)
+                val elements = base.findElements(by)
                 addDelay()
                 return elements.map { foundElement ->
                     decorateElement(foundElement)
@@ -72,6 +79,19 @@ public class SlowMotionDecorator(
                     decorateElement(foundElement)
                 }
             }
+        }
+    }
+
+    internal inner class SlowListener : WebDriverListener {
+        override fun beforeClick(element: WebElement) {
+            addDelay()
+        }
+
+        override fun beforeSendKeys(
+            element: WebElement,
+            vararg keysToSend: CharSequence,
+        ) {
+            addDelay()
         }
     }
 

--- a/core/selenium/src/test/kotlin/dev/kolibrium/core/selenium/internal/SlowMotionDecoratorTest.kt
+++ b/core/selenium/src/test/kotlin/dev/kolibrium/core/selenium/internal/SlowMotionDecoratorTest.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.seconds
 
-class SlowMotionDecoratorTest : BaseTest() {
+class SlowMotionDecoratorTest : BaseTest(isHeadless = false) {
     @BeforeEach
     fun setup() {
         DecoratorManager.addDecorators(

--- a/core/selenium/src/test/kotlin/dev/kolibrium/core/selenium/internal/WithDecoratorsTest.kt
+++ b/core/selenium/src/test/kotlin/dev/kolibrium/core/selenium/internal/WithDecoratorsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.core.selenium.internal
+
+import dev.kolibrium.core.selenium.decorators.BorderStyle
+import dev.kolibrium.core.selenium.decorators.Color
+import dev.kolibrium.core.selenium.decorators.DecoratorManager.withDecorators
+import dev.kolibrium.core.selenium.decorators.HighlighterDecorator
+import dev.kolibrium.core.selenium.decorators.SlowMotionDecorator
+import dev.kolibrium.core.selenium.idOrName
+import dev.kolibrium.core.selenium.name
+import org.junit.jupiter.api.Test
+import org.openqa.selenium.chrome.ChromeDriver
+import kotlin.time.Duration.Companion.seconds
+
+class WithDecoratorsTest {
+    @Test
+    fun test() {
+        ChromeDriver().apply {
+            withDecorators(
+                HighlighterDecorator(
+                    style = BorderStyle.DASHED,
+                    color = Color.GREEN,
+                ),
+                SlowMotionDecorator(wait = 3.seconds),
+            ) {
+                this.get("https://www.saucedemo.com/")
+                val usernameInput by name("user-name")
+                val passwordInput by idOrName("password")
+                val loginButton by name("login-button")
+
+                usernameInput.sendKeys("standard_user")
+                passwordInput.sendKeys("secret_sauce")
+                loginButton.click()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Introduce ListenerSupport to centralize WebDriver/WebElement listener wiring for decorators
- Update AbstractDecorator, HighlighterDecorator, SlowMotionDecorator, ElementStateCacheDecorator to use ListenerSupport and new lifecycle hooks
- Add WithDecoratorsTest to verify scoped decorator stacking/restoration
- Tweak SlowMotionDecoratorTest (disable headless) to surface highlighting/slow-mo behavior during runs