### PR TITLE
[DSL] Add cross site switch to switch back and more

### DIFF
--- a/core/selenium/api/selenium.api
+++ b/core/selenium/api/selenium.api
@@ -9,6 +9,10 @@ public final class dev/kolibrium/core/selenium/LocatorDelegatesKt {
 	public static synthetic fun cssSelectors$default (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
 	public static final fun dataTest (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;
 	public static synthetic fun dataTest$default (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
+	public static final fun dataTestId (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;
+	public static synthetic fun dataTestId$default (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
+	public static final fun dataTestIds (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;
+	public static synthetic fun dataTestIds$default (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
 	public static final fun dataTests (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;
 	public static synthetic fun dataTests$default (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
 	public static final fun id (Lorg/openqa/selenium/SearchContext;Ljava/lang/String;ZLdev/kolibrium/core/selenium/WaitConfig;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;
@@ -51,6 +55,8 @@ public abstract class dev/kolibrium/core/selenium/Page : org/openqa/selenium/Sea
 	public fun <init> (Lorg/openqa/selenium/WebDriver;)V
 	protected final fun addCookie (Lorg/openqa/selenium/Cookie;)V
 	protected final fun addCookies (Ljava/util/Set;)V
+	public fun assertReady ()V
+	public fun awaitReady (Lorg/openqa/selenium/WebDriver;)V
 	protected final fun back ()V
 	protected final fun clearCookies ()V
 	protected final fun cookie (Ljava/lang/String;)Lorg/openqa/selenium/Cookie;
@@ -62,6 +68,7 @@ public abstract class dev/kolibrium/core/selenium/Page : org/openqa/selenium/Sea
 	protected final fun getDriver ()Lorg/openqa/selenium/WebDriver;
 	protected final fun getPageTitle ()Ljava/lang/String;
 	public fun getPath ()Ljava/lang/String;
+	public fun getReadyBy ()Lorg/openqa/selenium/By;
 	protected final fun refresh ()V
 }
 
@@ -102,6 +109,10 @@ public final class dev/kolibrium/core/selenium/WaitConfig$Companion {
 	public final fun getDEFAULT ()Ldev/kolibrium/core/selenium/WaitConfig;
 	public final fun getPATIENT ()Ldev/kolibrium/core/selenium/WaitConfig;
 	public final fun getQUICK ()Ldev/kolibrium/core/selenium/WaitConfig;
+}
+
+public final class dev/kolibrium/core/selenium/WaitConfigKt {
+	public static final fun configureWith (Lorg/openqa/selenium/support/ui/FluentWait;Ldev/kolibrium/core/selenium/WaitConfig;)Lorg/openqa/selenium/support/ui/FluentWait;
 }
 
 public abstract class dev/kolibrium/core/selenium/decorators/AbstractDecorator {

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/Page.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/Page.kt
@@ -17,6 +17,7 @@
 package dev.kolibrium.core.selenium
 
 import dev.kolibrium.common.Cookies
+import org.openqa.selenium.By
 import org.openqa.selenium.Cookie
 import org.openqa.selenium.SearchContext
 import org.openqa.selenium.WebDriver
@@ -46,6 +47,18 @@ public abstract class Page<S : Site>(
     /** The current page title as reported by the driver. */
     protected val pageTitle: String?
         get() = driver.title
+
+    /**
+     * Optional canonical locator the DSL can wait for after navigation.
+     * If null, no built-in locator wait is performed.
+     */
+    public open val readyBy: By? = null
+
+    /** Optional custom wait implementation (no-op by default). */
+    public open fun awaitReady(driver: WebDriver): Unit = Unit
+
+    /** Optional identity/readiness guard (no-op by default). */
+    public open fun assertReady(): Unit = Unit
 
     /** Reloads the current page. */
     protected fun refresh() {

--- a/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/WaitConfig.kt
+++ b/core/selenium/src/main/kotlin/dev/kolibrium/core/selenium/WaitConfig.kt
@@ -17,6 +17,8 @@
 package dev.kolibrium.core.selenium
 
 import org.openqa.selenium.NoSuchElementException
+import org.openqa.selenium.support.ui.FluentWait
+import java.time.Duration.ofMillis
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -119,3 +121,20 @@ public class WaitConfig(
             )
     }
 }
+
+/**
+ * Apply this WaitConfig to a Selenium FluentWait instance.
+ * Generic across receiver types so it can be reused for WebDriver, WebElement wrappers, etc.
+ */
+public fun <T> FluentWait<T>.configureWith(waitConfig: WaitConfig): FluentWait<T> =
+    apply {
+        waitConfig.timeout?.let {
+            val withTimeout = withTimeout(ofMillis(it.inWholeMilliseconds))
+            withTimeout
+        }
+        waitConfig.pollingInterval?.let { pollingEvery(ofMillis(it.inWholeMilliseconds)) }
+        waitConfig.message?.let { withMessage { it } }
+        if (waitConfig.ignoring.isNotEmpty()) {
+            ignoreAll(waitConfig.ignoring.map { it.java })
+        }
+    }

--- a/dsl/api/dsl.api
+++ b/dsl/api/dsl.api
@@ -21,6 +21,7 @@ public final class dev/kolibrium/dsl/selenium/PageEntry {
 	public fun <init> (Lorg/openqa/selenium/WebDriver;)V
 	public final fun getDriver ()Lorg/openqa/selenium/WebDriver;
 	public final fun navigateTo (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/dsl/selenium/PageEntry;Ljava/lang/String;)V
+	public final fun on (Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public final fun open (Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public static synthetic fun open$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public final fun switchTo (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/core/selenium/Site;ZLjava/util/Set;)Ldev/kolibrium/dsl/selenium/PageEntry;
@@ -30,10 +31,11 @@ public final class dev/kolibrium/dsl/selenium/PageEntry {
 }
 
 public final class dev/kolibrium/dsl/selenium/PageScope {
-	public fun <init> (Ldev/kolibrium/core/selenium/Page;)V
+	public fun <init> (Ldev/kolibrium/core/selenium/Page;Lorg/openqa/selenium/WebDriver;)V
+	public final fun getDriver ()Lorg/openqa/selenium/WebDriver;
 	public final fun getPage ()Ldev/kolibrium/core/selenium/Page;
 	public final fun on (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
-	public final fun on (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun then (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public final fun unwrap ()Ldev/kolibrium/core/selenium/Page;
 	public final fun verify (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 }
@@ -46,6 +48,16 @@ public final class dev/kolibrium/dsl/selenium/SiteDslKt {
 	public static synthetic fun webTest$default (Ldev/kolibrium/core/selenium/Site;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 	public static final fun withSite (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;ZLkotlin/jvm/functions/Function2;)V
 	public static synthetic fun withSite$default (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class dev/kolibrium/dsl/selenium/SwitchBack {
+	public fun <init> (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;Ljava/lang/String;)V
+	public final fun switchBack (Lkotlin/jvm/functions/Function2;)Ldev/kolibrium/dsl/selenium/PageEntry;
+}
+
+public final class dev/kolibrium/dsl/selenium/SwitchBackScope {
+	public fun <init> (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;Ljava/lang/String;Ldev/kolibrium/core/selenium/Page;)V
+	public final fun switchBack (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 }
 
 public final class dev/kolibrium/dsl/selenium/actions/ActionsKt {

--- a/dsl/api/dsl.api
+++ b/dsl/api/dsl.api
@@ -19,8 +19,9 @@ public abstract interface annotation class dev/kolibrium/dsl/selenium/PageDsl : 
 
 public final class dev/kolibrium/dsl/selenium/PageEntry {
 	public fun <init> (Lorg/openqa/selenium/WebDriver;)V
-	public final fun cookies (Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageEntry;
-	public static synthetic fun cookies$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageEntry;
+	public final fun cookies (ZLkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageEntry;
+	public static synthetic fun cookies$default (Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageEntry;
+	public final fun ensureReady (Ldev/kolibrium/core/selenium/Page;Lorg/openqa/selenium/WebDriver;Ldev/kolibrium/core/selenium/Site;)V
 	public final fun getDriver ()Lorg/openqa/selenium/WebDriver;
 	public final fun navigateTo (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/dsl/selenium/PageEntry;Ljava/lang/String;)V
 	public final fun on (Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
@@ -31,8 +32,8 @@ public final class dev/kolibrium/dsl/selenium/PageEntry {
 }
 
 public final class dev/kolibrium/dsl/selenium/PageScope {
-	public fun <init> (Ldev/kolibrium/core/selenium/Page;Lorg/openqa/selenium/WebDriver;)V
-	public final fun getDriver ()Lorg/openqa/selenium/WebDriver;
+	public fun <init> (Ldev/kolibrium/core/selenium/Page;Ldev/kolibrium/dsl/selenium/PageEntry;)V
+	public final fun getEntry ()Ldev/kolibrium/dsl/selenium/PageEntry;
 	public final fun getPage ()Ldev/kolibrium/core/selenium/Page;
 	public final fun on (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public final fun then (Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;

--- a/dsl/api/dsl.api
+++ b/dsl/api/dsl.api
@@ -19,6 +19,8 @@ public abstract interface annotation class dev/kolibrium/dsl/selenium/PageDsl : 
 
 public final class dev/kolibrium/dsl/selenium/PageEntry {
 	public fun <init> (Lorg/openqa/selenium/WebDriver;)V
+	public final fun cookies (Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageEntry;
+	public static synthetic fun cookies$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageEntry;
 	public final fun getDriver ()Lorg/openqa/selenium/WebDriver;
 	public final fun navigateTo (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/dsl/selenium/PageEntry;Ljava/lang/String;)V
 	public final fun on (Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
@@ -26,8 +28,6 @@ public final class dev/kolibrium/dsl/selenium/PageEntry {
 	public static synthetic fun open$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public final fun switchTo (Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/core/selenium/Site;ZLjava/util/Set;)Ldev/kolibrium/dsl/selenium/PageEntry;
 	public static synthetic fun switchTo$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/core/selenium/Site;Ldev/kolibrium/core/selenium/Site;ZLjava/util/Set;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageEntry;
-	public final fun withCookies (Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageEntry;
-	public static synthetic fun withCookies$default (Ldev/kolibrium/dsl/selenium/PageEntry;Ldev/kolibrium/dsl/selenium/PageEntry;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageEntry;
 }
 
 public final class dev/kolibrium/dsl/selenium/PageScope {
@@ -41,6 +41,8 @@ public final class dev/kolibrium/dsl/selenium/PageScope {
 }
 
 public final class dev/kolibrium/dsl/selenium/SiteDslKt {
+	public static final fun cookies (Ldev/kolibrium/dsl/selenium/PageScope;ZLkotlin/jvm/functions/Function1;)Ldev/kolibrium/dsl/selenium/PageScope;
+	public static synthetic fun cookies$default (Ldev/kolibrium/dsl/selenium/PageScope;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kolibrium/dsl/selenium/PageScope;
 	public static final fun verify (Ldev/kolibrium/core/selenium/Page;Lkotlin/jvm/functions/Function1;)Ldev/kolibrium/core/selenium/Page;
 	public static final fun webTest (Ldev/kolibrium/core/selenium/Site;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
 	public static final fun webTest (Ldev/kolibrium/core/selenium/Site;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
@@ -628,6 +630,7 @@ public final class dev/kolibrium/dsl/selenium/interactions/CookiesKt {
 
 public final class dev/kolibrium/dsl/selenium/interactions/CookiesScope {
 	public fun <init> (Lorg/openqa/selenium/WebDriver$Options;)V
+	public final fun addAll ([Lorg/openqa/selenium/Cookie;)V
 	public final fun addCookie (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kolibrium/dsl/selenium/interactions/SameSite;)Lorg/openqa/selenium/Cookie;
 	public static synthetic fun addCookie$default (Ldev/kolibrium/dsl/selenium/interactions/CookiesScope;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kolibrium/dsl/selenium/interactions/SameSite;ILjava/lang/Object;)Lorg/openqa/selenium/Cookie;
 	public final fun deleteCookie (Ljava/lang/String;)V
@@ -635,6 +638,8 @@ public final class dev/kolibrium/dsl/selenium/interactions/CookiesScope {
 	public final fun deleteCookies ()V
 	public final fun getCookie (Ljava/lang/String;)Lorg/openqa/selenium/Cookie;
 	public final fun getCookies ()Ljava/util/Set;
+	public final fun put (Ljava/lang/String;Ljava/lang/String;)Lorg/openqa/selenium/Cookie;
+	public final fun putAll (Ljava/util/Map;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/SiteDsl.kt
+++ b/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/SiteDsl.kt
@@ -21,6 +21,7 @@ import dev.kolibrium.core.selenium.Page
 import dev.kolibrium.core.selenium.Site
 import dev.kolibrium.core.selenium.SiteContext
 import dev.kolibrium.dsl.selenium.interactions.CookiesScope
+import dev.kolibrium.dsl.selenium.interactions.cookies
 import dev.kolibrium.dsl.selenium.internal.normalizePath
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
@@ -262,11 +263,15 @@ public class PageEntry<S : Site>(
      * standard Selenium cookie management APIs. If [refreshPage] is true, the current page is refreshed
      * after the changes so that cookie effects take place immediately.
      *
+     * Notes:
+     * - Selenium only allows adding cookies for the current origin. Ensure the driver is already on the target site's origin.
+     * - This function does not auto-refresh unless [refreshPage] is true.
+     *
      * @param refreshPage Whether to refresh the page after applying cookie changes. Default is false.
      * @param builder The cookie modification DSL.
      * @return This [PageEntry] for fluent chaining.
      */
-    public fun PageEntry<S>.withCookies(
+    public fun PageEntry<S>.cookies(
         refreshPage: Boolean = false,
         builder: CookiesScope.() -> Unit,
     ): PageEntry<S> {
@@ -523,4 +528,15 @@ public inline fun <reified S2 : Site, P : Page<*>> PageScope<P>.switchTo(
         originalWindow = originalWindow,
         originalPage = this.page,
     )
+}
+
+/**
+ * Add or manipulate cookies while staying on the same page scope.
+ */
+public fun <P : Page<*>> PageScope<P>.cookies(
+    refreshPage: Boolean = false,
+    builder: CookiesScope.() -> Unit,
+): PageScope<P> {
+    driver.cookies(refreshPage, builder)
+    return this
 }

--- a/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/interactions/Navigation.kt
+++ b/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/interactions/Navigation.kt
@@ -17,6 +17,7 @@
 package dev.kolibrium.dsl.selenium.interactions
 
 import dev.kolibrium.dsl.selenium.KolibriumDsl
+import dev.kolibrium.dsl.selenium.internal.normalizePath
 import org.openqa.selenium.WebDriver
 
 /**
@@ -36,7 +37,7 @@ public fun WebDriver.navigateTo(relativePath: String) {
     val current = java.net.URI(currentUrl)
     val origin = java.net.URI("${current.scheme}://${current.authority}/")
 
-    val normalizedPath = if (path.startsWith('/')) path else "/$path"
+    val normalizedPath = normalizePath(path)
 
     val resolved = origin.resolve(normalizedPath)
     get(resolved.toString())

--- a/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/internal/UrlUtils.kt
+++ b/dsl/src/main/kotlin/dev/kolibrium/dsl/selenium/internal/UrlUtils.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.dsl.selenium.internal
+
+/**
+ * Normalize a relative path to ensure it begins with a leading slash and is trimmed.
+ *
+ * Absolute URLs (http/https) should be handled by the caller before invoking this.
+ */
+internal fun normalizePath(path: String): String {
+    val trimmed = path.trim()
+    return if (trimmed.startsWith('/')) trimmed else "/$trimmed"
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/bstackdemo/BrowserStackDemoTest.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/bstackdemo/BrowserStackDemoTest.kt
@@ -16,6 +16,7 @@
 
 package dev.kolibrium.dsl.selenium.webtest.bstackdemo
 
+import com.titusfortner.logging.SeleniumLogger
 import dev.kolibrium.dsl.selenium.DriverFactory
 import dev.kolibrium.dsl.selenium.PageEntry
 import dev.kolibrium.dsl.selenium.creation.Arguments.Chrome.disable_search_engine_choice_screen
@@ -27,11 +28,20 @@ import dev.kolibrium.dsl.selenium.webtest.bstackdemo.Product.IPHONE_12
 import dev.kolibrium.dsl.selenium.webtest.bstackdemo.Product.IPHONE_12_MINI
 import dev.kolibrium.dsl.selenium.webtest.bstackdemo.backend.getProducts
 import dev.kolibrium.dsl.selenium.webtest.bstackdemo.pages.ProductsPage
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.openqa.selenium.chrome.ChromeDriver
 
 class BrowserStackDemoTest {
     private val products = listOf(IPHONE_12, IPHONE_12_MINI)
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun enableLogging() {
+            SeleniumLogger.enable("RemoteWebDriver")
+        }
+    }
 
     @Test
     fun test() =

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/bstackdemo/BrowserStackDemoTest.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/bstackdemo/BrowserStackDemoTest.kt
@@ -48,9 +48,7 @@ class BrowserStackDemoTest {
             },
         ) { productIds ->
             ProductsPage(driver).apply {
-                productIds.forEach { productId ->
-                    addToCart(productId)
-                }
+                productIds.forEach(::addToCart)
 
                 verifyShoppingCartBadgeIs(products.size)
             }

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemo.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemo.kt
@@ -44,3 +44,19 @@ data object SauceDemo : Site(baseUrl = "https://www.saucedemo.com") {
             LoggerDecorator(),
         )
 }
+
+data object Twitter : Site(baseUrl = "https://www.x.com") {
+    override val elementReadyCondition: (WebElement.() -> Boolean) = { isClickable }
+
+    override val waitConfig: WaitConfig = QUICK
+
+    override val decorators: List<AbstractDecorator> =
+        listOf(
+            HighlighterDecorator(
+                style = BorderStyle.DASHED,
+                color = Color.GREEN,
+            ),
+            SlowMotionDecorator(wait = 300.milliseconds),
+            LoggerDecorator(),
+        )
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemoTest.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemoTest.kt
@@ -188,7 +188,7 @@ class SauceDemoTest() {
         driverFactory = driverFactory,
         prepare = { user.acquireCredentials() },
         startup = { username: String ->
-            withCookies {
+            cookies {
                 addCookie("session-username", username)
             }
         },

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemoTest.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/SauceDemoTest.kt
@@ -149,7 +149,7 @@ class SauceDemoTest() {
     @Test
     fun `crossing domains`() = authenticatedSauceDemoTest(
         user = User.Visual,
-        keepBrowserOpen = true,
+        keepBrowserOpen = false,
     ) {
         open(::InventoryPage) {
             visitTwitter()

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/User.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/User.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.dsl.selenium.webtest.saucedemo
+
+enum class User(
+    val username: String,
+) {
+    Standard("standard_user"),
+    LockedOut("locked_out_user"),
+    Problem("problem_user"),
+    PerformanceGlitch("performance_glitch_user"),
+    Error("error_user"),
+    Visual("visual_user"),
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/CartPage.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/CartPage.kt
@@ -21,6 +21,7 @@ import dev.kolibrium.core.selenium.dataTest
 import dev.kolibrium.core.selenium.dataTests
 import dev.kolibrium.core.selenium.idOrName
 import dev.kolibrium.dsl.selenium.webtest.saucedemo.SauceDemo
+import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 
@@ -28,6 +29,8 @@ class CartPage(
     driver: WebDriver,
 ) : Page<SauceDemo>(driver) {
     override val path = "/cart.html"
+
+    override val readyBy = By.className("title")
 
     private val inventoryItems by dataTests("inventory-item")
     private val continueShoppingButton by idOrName("continue-shopping")

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/Footer.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/Footer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.dsl.selenium.webtest.saucedemo.pages
+
+import dev.kolibrium.core.selenium.Page
+import dev.kolibrium.core.selenium.dataTest
+import dev.kolibrium.dsl.selenium.webtest.saucedemo.SauceDemo
+
+// Return the current page so callers can continue fluent chains that expect a Page
+context(page: Page<SauceDemo>)
+fun visitTwitter(): InventoryPage {
+    val twitterLogo by page.dataTest("social-twitter")
+    twitterLogo.click()
+    // We know callers use this from InventoryPage in tests; return it for chaining
+    return page as InventoryPage
+}
+
+context(page: Page<SauceDemo>)
+fun visitFacebook() {
+    val facebookLogo by page.dataTest("social-facebook")
+    facebookLogo.click()
+}
+
+context(page: Page<SauceDemo>)
+fun visitLinkedIn() {
+    val linkedInLogo by page.dataTest("social-linkedin")
+    linkedInLogo.click()
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/FeedPage.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/FeedPage.kt
@@ -18,11 +18,16 @@ package dev.kolibrium.dsl.selenium.webtest.saucedemo.pages.twitter
 
 import dev.kolibrium.core.selenium.Page
 import dev.kolibrium.dsl.selenium.webtest.saucedemo.Twitter
+import io.kotest.matchers.shouldBe
 import org.openqa.selenium.WebDriver
 
 class FeedPage(
     driver: WebDriver,
 ) : Page<Twitter>(driver) {
+    override fun assertReady() {
+        pageTitle shouldBe "Sauce Labs (@saucelabs) / X"
+    }
+
     fun likeKolibrium() {
     }
 }

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/FeedPage.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/FeedPage.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.dsl.selenium.webtest.saucedemo.pages.twitter
+
+import dev.kolibrium.core.selenium.Page
+import dev.kolibrium.dsl.selenium.webtest.saucedemo.Twitter
+import org.openqa.selenium.WebDriver
+
+class FeedPage(
+    driver: WebDriver,
+) : Page<Twitter>(driver) {
+    fun likeKolibrium() {
+    }
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/TwitterHomePage.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/TwitterHomePage.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023-2025 Attila Fazekas & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.kolibrium.dsl.selenium.webtest.saucedemo.pages.twitter
+
+import dev.kolibrium.core.selenium.Page
+import dev.kolibrium.dsl.selenium.webtest.saucedemo.Twitter
+import org.openqa.selenium.WebDriver
+
+class TwitterHomePage(
+    driver: WebDriver,
+) : Page<Twitter>(driver) {
+    fun login(): FeedPage = FeedPage(driver)
+}

--- a/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/TwitterHomePage.kt
+++ b/dsl/src/test/kotlin/dev/kolibrium/dsl/selenium/webtest/saucedemo/pages/twitter/TwitterHomePage.kt
@@ -18,10 +18,13 @@ package dev.kolibrium.dsl.selenium.webtest.saucedemo.pages.twitter
 
 import dev.kolibrium.core.selenium.Page
 import dev.kolibrium.dsl.selenium.webtest.saucedemo.Twitter
+import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 
 class TwitterHomePage(
     driver: WebDriver,
 ) : Page<Twitter>(driver) {
+    override val readyBy = By.xpath(".//*[@data-testid='tweet']")
+
     fun login(): FeedPage = FeedPage(driver)
 }

--- a/konsistTest/src/test/kotlin/dev/kolibrium/KonsistTest.kt
+++ b/konsistTest/src/test/kotlin/dev/kolibrium/KonsistTest.kt
@@ -67,7 +67,7 @@ class KonsistTest {
     @Test
     fun `properties are declared before functions`() {
         Konsist
-            .scopeFromProject()
+            .scopeFromProduction()
             .classes()
             .assertTrue {
                 val lastKoPropertyDeclarationIndex =


### PR DESCRIPTION
Core: added `dataTestId`/`dataTestIds` locators and a page readiness pipeline (`path`, `readyBy`, `awaitReady`, `assertReady`), plus tighter `WaitConfig` with presets.

DSL: introduced a fluent page flow (`PageScope` with `on`/`then`/`verify`), cross‑site `switchTo`/`switchBack`, URL normalization/navigation helpers, and a safer cookies DSL; tests and examples updated.